### PR TITLE
Update shellcheck URL in test_shell.sh

### DIFF
--- a/ci/test_shell.sh
+++ b/ci/test_shell.sh
@@ -11,7 +11,7 @@ if ! [ -x "$(command -v bats)" ]; then
 fi
 if ! [ -x "$(command -v shellcheck)" ]; then
     echo "=== install shellcheck ==="
-    wget https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz
+    wget https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
     tar -xvf shellcheck-stable.linux.x86_64.tar.xz
 fi
 . tools/venv/bin/activate


### PR DESCRIPTION
The URL to download `shellcheck` is out-dated. Updating to the new one.
In this PR, I might also update this doc page: https://github.com/espnet/espnet/blob/master/CONTRIBUTING.md#unit-testing since it is also a bit out-dated. For example, `./ci/test_bash.sh` does not exist anymore and has been integrated into `./ci/test_shell.sh`.